### PR TITLE
Add investor login and signup

### DIFF
--- a/app/api/cas/callback/route.ts
+++ b/app/api/cas/callback/route.ts
@@ -77,7 +77,7 @@ export async function GET(request: Request) {
   }
 
   // 4) Set a cookie with user info, then redirect
-  const user = { netid, name: fullName };
+  const user = { netid, name: fullName, type: 'student' };
 
   const response = NextResponse.redirect(`${origin}/account`);
   response.cookies.set('user', JSON.stringify(user), {

--- a/app/api/investor/login/route.ts
+++ b/app/api/investor/login/route.ts
@@ -1,0 +1,39 @@
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+import { verifyPassword } from '@/lib/authUtils';
+
+export async function POST(request: Request) {
+  try {
+    const { email, password } = await request.json();
+    if (!email || !password) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    }
+    const { data, error } = await supabase
+      .from('investors')
+      .select('email,name,password')
+      .eq('email', email)
+      .single();
+    if (error || !data) {
+      return NextResponse.json({ error: 'Invalid email or password' }, { status: 401 });
+    }
+    if (!verifyPassword(data.password, password)) {
+      return NextResponse.json({ error: 'Invalid email or password' }, { status: 401 });
+    }
+    const user = { email: data.email, name: data.name, type: 'investor' };
+    const response = NextResponse.json({ success: true });
+    response.cookies.set('user', JSON.stringify(user), {
+      path: '/',
+      maxAge: 60 * 60 * 24 * 7,
+      secure: true,
+      sameSite: 'strict',
+      httpOnly: false,
+    });
+    return response;
+  } catch (err) {
+    console.error('Login error:', err);
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/app/api/investor/signup/route.ts
+++ b/app/api/investor/signup/route.ts
@@ -1,0 +1,27 @@
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+import { hashPassword } from '@/lib/authUtils';
+
+export async function POST(request: Request) {
+  try {
+    const { email, name, firm, title, password } = await request.json();
+    if (!email || !name || !password) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+    const hashed = hashPassword(password);
+    const { error } = await supabase
+      .from('investors')
+      .insert({ email, name, firm, title, password: hashed });
+    if (error) {
+      console.error('Supabase insert error:', error);
+      return NextResponse.json({ error: 'Database error' }, { status: 500 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('Signup error:', err);
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleStudent = () => {
+    window.location.href = '/api/cas/login';
+  };
+
+  const handleInvestor = async (e: FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/investor/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (res.ok) {
+        router.push('/account');
+      } else {
+        const data = await res.json();
+        setError(data.error || 'Login failed');
+      }
+    } catch (err) {
+      setError('Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-grow flex items-center justify-center p-4">
+        <div className="w-full max-w-md space-y-6">
+          <h1 className="text-2xl font-semibold text-center">Login</h1>
+          <button
+            onClick={handleStudent}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-2"
+          >
+            Login as Yale Student
+          </button>
+          <form onSubmit={handleInvestor} className="space-y-4 border-t pt-4">
+            {error && <p className="text-red-600 text-sm">{error}</p>}
+            <div>
+              <label className="block text-sm font-medium mb-1">Email</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full border rounded px-3 py-2"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Password</label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full border rounded px-3 py-2"
+                required
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-2"
+            >
+              {loading ? 'Logging in...' : 'Login as Investor'}
+            </button>
+          </form>
+          <p className="text-sm text-center">
+            Don't have an account?{' '}
+            <a href="/signup" className="text-blue-600 hover:underline">
+              Sign up
+            </a>
+          </p>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,124 @@
+'use client';
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+
+export default function SignupPage() {
+  const router = useRouter();
+  const [form, setForm] = useState({
+    email: '',
+    name: '',
+    firm: '',
+    title: '',
+    password: '',
+  });
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/investor/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        router.push('/login');
+      } else {
+        const data = await res.json();
+        setError(data.error || 'Signup failed');
+      }
+    } catch (err) {
+      setError('Signup failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-grow flex items-center justify-center p-4">
+        <form onSubmit={handleSubmit} className="w-full max-w-md space-y-4">
+          <h1 className="text-2xl font-semibold text-center">Investor Signup</h1>
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+          <div>
+            <label className="block text-sm font-medium mb-1">Email</label>
+            <input
+              type="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              required
+              className="w-full border rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Name</label>
+            <input
+              type="text"
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              required
+              className="w-full border rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Firm</label>
+            <input
+              type="text"
+              name="firm"
+              value={form.firm}
+              onChange={handleChange}
+              className="w-full border rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Title</label>
+            <input
+              type="text"
+              name="title"
+              value={form.title}
+              onChange={handleChange}
+              className="w-full border rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Password</label>
+            <input
+              type="password"
+              name="password"
+              value={form.password}
+              onChange={handleChange}
+              required
+              className="w-full border rounded px-3 py-2"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-2"
+          >
+            {loading ? 'Signing up...' : 'Create Account'}
+          </button>
+          <p className="text-sm text-center">
+            Already have an account?{' '}
+            <a href="/login" className="text-blue-600 hover:underline">
+              Log in
+            </a>
+          </p>
+        </form>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -2,8 +2,10 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
 interface User {
-  netid: string;
+  netid?: string;
+  email?: string;
   name: string;
+  type: 'student' | 'investor';
 }
 
 interface AuthContextType {
@@ -33,17 +35,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         try {
           // Decode the cookie value before parsing as JSON
           const parsed = JSON.parse(decodeURIComponent(userCookie));
+          if (!parsed.type) {
+            parsed.type = parsed.netid ? 'student' : 'investor';
+          }
           setUser(parsed);
         } catch (error) {
           console.error("Error parsing user cookie:", error);
-          setUser({ netid: userCookie, name: userCookie });
+          setUser({ netid: userCookie, name: userCookie, type: 'student' });
         }
       }
     }
   }, []);
 
   const login = () => {
-    window.location.href = "/api/cas/login";
+    window.location.href = "/login";
   };
 
   const logout = () => {

--- a/lib/authUtils.ts
+++ b/lib/authUtils.ts
@@ -1,0 +1,14 @@
+import { randomBytes, scryptSync } from 'crypto';
+
+export function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const derived = scryptSync(password, salt, 64);
+  return `${salt}:${derived.toString('hex')}`;
+}
+
+export function verifyPassword(stored: string, password: string): boolean {
+  const [salt, hash] = stored.split(':');
+  if (!salt || !hash) return false;
+  const derived = scryptSync(password, salt, 64);
+  return derived.toString('hex') === hash;
+}


### PR DESCRIPTION
## Summary
- enable investor login and signup
- create investor auth API endpoints
- hash passwords with Node crypto
- allow AuthContext to handle students and investors
- add login page with student or investor choice
- add signup page for investors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d6ecd97088320b6bb4687e695fc97