### PR TITLE
Fix investor login refresh

### DIFF
--- a/app/api/cas/callback/route.ts
+++ b/app/api/cas/callback/route.ts
@@ -98,7 +98,7 @@ export async function GET(request: Request) {
   response.cookies.set('user', JSON.stringify(user), {
     path: '/',
     maxAge: 60 * 60 * 24 * 7, // 7 days
-    secure: true,
+    secure: process.env.NODE_ENV === 'production',
     sameSite: 'strict',
     httpOnly: false,
   });

--- a/app/api/investor/login/route.ts
+++ b/app/api/investor/login/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: Request) {
     response.cookies.set('user', JSON.stringify(user), {
       path: '/',
       maxAge: 60 * 60 * 24 * 7,
-      secure: true,
+      secure: process.env.NODE_ENV === 'production',
       sameSite: 'strict',
       httpOnly: false,
     });

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -26,7 +26,7 @@ export default function LoginPage() {
         body: JSON.stringify({ email, password }),
       });
       if (res.ok) {
-        router.push('/account');
+        window.location.href = '/account';
       } else {
         const data = await res.json();
         setError(data.error || 'Login failed');


### PR DESCRIPTION
## Summary
- refresh browser after investor login so AuthContext reloads
- set cookies as secure only in production for local dev testing

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688556b5fb248320b89de9cf62c1d3d7